### PR TITLE
feat(git_repos): GitHub user repo enumeration with archive handling

### DIFF
--- a/ansible/inventory/host_vars/svlazdev.yml
+++ b/ansible/inventory/host_vars/svlazdev.yml
@@ -1,0 +1,68 @@
+---
+# Host-specific variables for svlazdev
+
+# Environment classification
+server_environment: development
+
+# GitHub username for SSH keys installation
+github_ssh_keys_username: DevSecNinja
+
+# User that will receive the SSH keys from GitHub
+github_ssh_keys_target_user: jean-paul
+
+# Ensure only GitHub SSH Keys are kept, removes other SSH keys
+github_ssh_keys_exclusive: true
+
+# Chezmoi dotfiles user
+chezmoi_user: jean-paul
+
+# Homebrew is used interactively by the dotfiles user.
+homebrew_user: jean-paul
+
+# Mise version manager
+install_mise: true
+mise_user: jean-paul
+
+# Devcontainer prebuild
+devcontainer_prebuild_user: jean-paul
+
+# Keep stopped devcontainer containers so VS Code can fast-attach;
+# their referenced images are also protected from image prune
+maintenance_docker_prune_containers_enabled: false
+
+# Server features to enable
+server_features:
+  - system_setup
+  - github_ssh_keys
+  - docker
+  - ufw
+  - package_managers
+  - chezmoi
+  - ansible_pull_setup
+  - maintenance
+  - packages
+  - git_repos
+  - devcontainer_prebuild
+
+# Packages to install
+packages_apt:
+  - git-lfs
+  - jq
+
+# Clone every non-archived public repository owned by the GitHub handle and
+# relocate any repositories that have since been archived into the
+# projects/.archive folder.
+git_repos:
+  - github_user: DevSecNinja
+    dest: "/home/jean-paul/projects"
+    user: jean-paul
+    group: jean-paul
+    archive_mode: true
+
+# Docker Compose modules to deploy
+compose_modules: []
+
+# Users to add to docker group
+docker_users:
+  - ansible
+  - jean-paul

--- a/ansible/inventory/hosts.yml
+++ b/ansible/inventory/hosts.yml
@@ -15,6 +15,11 @@ all:
           ansible_connection: local
           ansible_user: ansible
           ansible_become: true
+        svlazdev:
+          ansible_host: svlazdev
+          ansible_connection: local
+          ansible_user: ansible
+          ansible_become: true
     docker_servers:
       children:
         application_servers:

--- a/ansible/roles/git_repos/defaults/main.yml
+++ b/ansible/roles/git_repos/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Default variables for Git Repos role
 
-# List of repositories to clone. Two formats are supported:
+# List of repositories to clone. Three formats are supported:
 #
 # Single-repo format (repo cloned directly into dest):
 # git_repos:
@@ -20,4 +20,36 @@
 #     version: main  # optional, defaults to HEAD (remote default branch)
 #     user: myuser
 #     group: myuser
+#
+# GitHub-user format (enumerate a handle's repos via the GitHub API and clone
+# each non-archived public repo into dest/<repo-name>):
+# git_repos:
+#   - github_user: "octocat"
+#     dest: "/home/myuser/projects"
+#     user: myuser
+#     group: myuser
+#     # Optional: also clone archived public repos (default: false).
+#     include_archived: false
+#     # Optional: move already-cloned archived repos into dest/.archive
+#     # (default: false). Takes precedence over include_archived for archived
+#     # repos, so they are relocated rather than (re)cloned.
+#     archive_mode: false
+#     # Optional: personal access token for authenticated API requests
+#     # (raises the rate limit). Falls back to git_repos_github_token.
+#     token: ""
+#     # Optional: cap the number of repositories cloned (0 = no limit,
+#     # default). Useful for testing.
+#     limit: 0
 git_repos: []
+
+# Base URL for the GitHub REST API (override for GitHub Enterprise).
+git_repos_github_api_url: "https://api.github.com"
+
+# Maximum number of API result pages (100 repos each) to fetch per github_user
+# entry. Increase if a user owns more than this many repositories.
+git_repos_github_max_pages: 5
+
+# Default token used for authenticated GitHub API requests when a github_user
+# entry does not define its own 'token'. Leave empty for unauthenticated
+# requests (subject to a lower rate limit).
+git_repos_github_token: ""

--- a/ansible/roles/git_repos/tasks/github_user.yml
+++ b/ansible/roles/git_repos/tasks/github_user.yml
@@ -1,0 +1,127 @@
+---
+# Synchronise all public repositories of a single GitHub user.
+# Expects the loop variable 'git_repos_entry' (github_user format).
+
+- name: "Resolve settings for GitHub user '{{ git_repos_entry.github_user }}'"
+  ansible.builtin.set_fact:
+    git_repos_dest: "{{ git_repos_entry.dest }}"
+    git_repos_owner: "{{ git_repos_entry.user | default(ansible_user) }}"
+    git_repos_group: >-
+      {{ git_repos_entry.group
+         | default(git_repos_entry.user | default(ansible_user)) }}
+    git_repos_include_archived: >-
+      {{ git_repos_entry.include_archived | default(false) | bool }}
+    git_repos_archive_mode: >-
+      {{ git_repos_entry.archive_mode | default(false) | bool }}
+    git_repos_resolved_token: >-
+      {{ git_repos_entry.token | default(git_repos_github_token) }}
+    git_repos_limit: >-
+      {{ git_repos_entry.limit | default(0) | int }}
+  tags: [git_repos]
+
+- name: "Query GitHub API for repositories of '{{ git_repos_entry.github_user }}'"
+  ansible.builtin.uri:
+    url: >-
+      {{ git_repos_github_api_url }}/users/{{ git_repos_entry.github_user }}/repos?per_page=100&page={{ item }}&type=owner&sort=full_name
+    method: GET
+    return_content: true
+    headers: >-
+      {{ {'Accept': 'application/vnd.github+json'}
+         | combine({'Authorization': 'Bearer ' + git_repos_resolved_token}
+                   if git_repos_resolved_token | length > 0 else {}) }}
+  loop: "{{ range(1, (git_repos_github_max_pages | int) + 1) | list }}"
+  register: git_repos_api_pages
+  until: git_repos_api_pages is succeeded
+  retries: 3
+  delay: 5
+  check_mode: false
+  changed_when: false
+  no_log: "{{ git_repos_resolved_token | length > 0 }}"
+  tags: [git_repos]
+
+- name: "Build repository lists for '{{ git_repos_entry.github_user }}'"
+  ansible.builtin.set_fact:
+    git_repos_public: >-
+      {{ git_repos_api_pages.results
+         | map(attribute='json') | flatten
+         | rejectattr('private') | list }}
+  tags: [git_repos]
+
+- name: "Select archived and clone targets for '{{ git_repos_entry.github_user }}'"
+  ansible.builtin.set_fact:
+    git_repos_archived: >-
+      {{ git_repos_public | selectattr('archived') | list }}
+    git_repos_clone_candidates: >-
+      {{ git_repos_public
+         if (git_repos_include_archived and not git_repos_archive_mode)
+         else (git_repos_public | rejectattr('archived') | list) }}
+  tags: [git_repos]
+
+- name: "Apply clone limit for '{{ git_repos_entry.github_user }}'"
+  ansible.builtin.set_fact:
+    git_repos_to_clone: >-
+      {{ git_repos_clone_candidates[:git_repos_limit]
+         if git_repos_limit > 0
+         else git_repos_clone_candidates }}
+  tags: [git_repos]
+
+- name: "Ensure projects directory exists for '{{ git_repos_entry.github_user }}'"
+  ansible.builtin.file:
+    path: "{{ git_repos_dest }}"
+    state: directory
+    owner: "{{ git_repos_owner }}"
+    group: "{{ git_repos_group }}"
+    mode: "0755"
+  become: true
+  tags: [git_repos]
+
+- name: "Clone or update repositories for '{{ git_repos_entry.github_user }}'"
+  ansible.builtin.git:
+    repo: "{{ item.clone_url }}"
+    dest: "{{ git_repos_dest }}/{{ item.name }}"
+    version: "{{ item.default_branch }}"
+    update: true
+  loop: "{{ git_repos_to_clone }}"
+  loop_control:
+    label: "{{ item.name }}"
+  become: true
+  become_user: "{{ git_repos_owner }}"
+  environment:
+    GIT_TERMINAL_PROMPT: "0"
+  register: git_repos_user_clone_result
+  failed_when:
+    - git_repos_user_clone_result.failed
+    - >-
+      'Local modifications exist' not in
+      (git_repos_user_clone_result.msg | default(''))
+    - "'git-lfs' not in (git_repos_user_clone_result.stderr | default(''))"
+    - >-
+      'not found' not in
+      (git_repos_user_clone_result.msg | default('') | lower)
+  tags: [git_repos]
+
+- name: "Relocate archived repositories for '{{ git_repos_entry.github_user }}'"
+  when: git_repos_archive_mode
+  tags: [git_repos]
+  block:
+    - name: "Ensure .archive directory exists in '{{ git_repos_dest }}'"
+      ansible.builtin.file:
+        path: "{{ git_repos_dest }}/.archive"
+        state: directory
+        owner: "{{ git_repos_owner }}"
+        group: "{{ git_repos_group }}"
+        mode: "0755"
+      become: true
+
+    - name: "Move archived repositories into {{ git_repos_dest }}/.archive"
+      ansible.builtin.command:
+        cmd: >-
+          mv {{ (git_repos_dest + '/' + item.name) | quote }}
+             {{ (git_repos_dest + '/.archive/' + item.name) | quote }}
+        removes: "{{ git_repos_dest }}/{{ item.name }}"
+        creates: "{{ git_repos_dest }}/.archive/{{ item.name }}"
+      loop: "{{ git_repos_archived }}"
+      loop_control:
+        label: "{{ item.name }}"
+      become: true
+      become_user: "{{ git_repos_owner }}"

--- a/ansible/roles/git_repos/tasks/main.yml
+++ b/ansible/roles/git_repos/tasks/main.yml
@@ -49,3 +49,11 @@
     - "'git-lfs' not in (git_multi_result.stderr | default(''))"
     - "'not found' not in (git_multi_result.msg | default('') | lower)"
   tags: [git_repos]
+
+- name: Synchronise repositories for GitHub users
+  ansible.builtin.include_tasks: github_user.yml
+  loop: "{{ git_repos | selectattr('github_user', 'defined') | list }}"
+  loop_control:
+    loop_var: git_repos_entry
+    label: "{{ git_repos_entry.github_user }}"
+  tags: [git_repos]

--- a/tests/bash/README.md
+++ b/tests/bash/README.md
@@ -19,7 +19,9 @@ tests/bash/
 ├── lint-test.bats            # Linting tests (yamllint, ansible-lint)
 ├── syntax-test.bats          # Syntax validation tests
 ├── docker-test.bats          # Docker provisioning tests
-└── ansible-pull-test.bats    # ansible-pull functionality tests
+├── ansible-pull-test.bats    # ansible-pull functionality tests
+├── github-ssh-keys-test.bats # github_ssh_keys role tests
+└── git-repos-test.bats       # git_repos role tests (github_user format + e2e clone)
 ```
 
 ## Running Tests
@@ -121,6 +123,17 @@ Tests ansible-pull functionality:
 - ansible-pull script exists and is valid
 - ansible-pull can run from local repository
 - Inventory files are in correct locations
+
+### Git Repos Tests (`git-repos-test.bats`)
+
+Tests the `git_repos` role `github_user` enumeration format:
+- Role task and defaults files exist
+- `github_user.yml` task file is valid YAML
+- `main.yml` wires in the `github_user` sub-tasks
+- The GitHub repos API is reachable for the test user
+- End-to-end: applies the role against `localhost` for a real GitHub
+  handle, capped to a single repository via `limit: 1`, and asserts exactly
+  one repository was cloned (CI only — requires sudo and network access)
 
 ## CI/CD Integration
 

--- a/tests/bash/git-repos-test.bats
+++ b/tests/bash/git-repos-test.bats
@@ -1,0 +1,84 @@
+#!/usr/bin/env bats
+# Tests for the git_repos role (github_user enumeration format)
+
+# Setup function runs before each test
+setup() {
+	# Get repository root
+	REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+	export REPO_ROOT
+	ANSIBLE_DIR="${REPO_ROOT}/ansible"
+	export ANSIBLE_DIR
+	ROLE_DIR="${ANSIBLE_DIR}/roles/git_repos"
+	export ROLE_DIR
+	# GitHub user enumerated by the end-to-end test
+	GH_TEST_USER="DevSecNinja"
+	export GH_TEST_USER
+}
+
+@test "git-repos-test: role files exist" {
+	[ -f "$ROLE_DIR/tasks/main.yml" ]
+	[ -f "$ROLE_DIR/tasks/github_user.yml" ]
+	[ -f "$ROLE_DIR/defaults/main.yml" ]
+}
+
+@test "git-repos-test: github_user task file is valid YAML" {
+	if ! command -v yamllint >/dev/null 2>&1; then
+		run pip install yamllint
+		[ "$status" -eq 0 ]
+	fi
+	cd "$REPO_ROOT"
+	run yamllint "$ROLE_DIR/tasks/github_user.yml"
+	[ "$status" -eq 0 ]
+}
+
+@test "git-repos-test: main task file includes github_user sub-tasks" {
+	run grep -q "github_user.yml" "$ROLE_DIR/tasks/main.yml"
+	[ "$status" -eq 0 ]
+}
+
+@test "git-repos-test: GitHub repos API is accessible for test user" {
+	# Verify the public repositories endpoint responds
+	run curl -f -s "https://api.github.com/users/${GH_TEST_USER}/repos?per_page=1"
+	[ "$status" -eq 0 ]
+	# Response must be a JSON array
+	[[ "$output" =~ ^\[ ]]
+}
+
+@test "git-repos-test: end-to-end clone of a single repo" {
+	# Requires sudo (apt) and network access; only run in CI
+	if [ "$CI" != "true" ]; then
+		skip "Skipping e2e clone test in local environment (requires sudo + network)"
+	fi
+
+	local dest="/tmp/git-repos-e2e"
+	rm -rf "$dest"
+
+	# Minimal playbook that applies only the git_repos role, capped at one repo
+	cat > /tmp/git-repos-e2e-playbook.yml <<EEOF
+---
+- name: E2E test git_repos github_user format
+  hosts: localhost
+  connection: local
+  become: true
+  vars:
+    ansible_user: runner
+    git_repos:
+      - github_user: ${GH_TEST_USER}
+        dest: ${dest}
+        user: runner
+        group: runner
+        limit: 1
+  roles:
+    - role: git_repos
+EEOF
+
+	# Run from the repository root so ansible.cfg resolves roles_path
+	cd "$REPO_ROOT"
+	run timeout 180 ansible-playbook /tmp/git-repos-e2e-playbook.yml
+	[ "$status" -eq 0 ]
+
+	# Exactly one repository should have been cloned
+	local cloned
+	cloned=$(find "$dest" -mindepth 2 -maxdepth 2 -name ".git" -type d | wc -l)
+	[ "$cloned" -eq 1 ]
+}


### PR DESCRIPTION
## Summary

Adds a third `git_repos` entry format that enumerates a GitHub handle's public repositories via the GitHub REST API and clones each non-archived public repo into `dest/<name>`.

### New `github_user` format

```yaml
git_repos:
  - github_user: DevSecNinja
    dest: "/home/jean-paul/projects"
    user: jean-paul
    group: jean-paul
    include_archived: false   # toggle (default false): also clone archived public repos
    archive_mode: false       # toggle (default false): move already-cloned archived repos to dest/.archive
    limit: 0                  # optional: cap number of repos cloned (0 = no limit)
    token: ""                # optional: PAT for authenticated API requests (no_log protected)
```

- **`include_archived`** (default `false`) — when `false`, only non-archived public repos are cloned.
- **`archive_mode`** (default `false`) — relocates already-cloned archived repos into `dest/.archive` (idempotent via `mv` guarded by `creates`/`removes`).
- **`limit`** — caps how many repos are cloned (used by the e2e test).
- **`token`** — optional authenticated requests for a higher rate limit; suppressed from logs via `no_log`.

## Tests

`tests/bash/git-repos-test.bats`:
- Role files exist
- `github_user.yml` passes yamllint
- `main.yml` wires in the sub-tasks
- GitHub repos API is reachable
- **End-to-end**: applies the role against `localhost` for a real handle capped to one repo (`limit: 1`) and asserts exactly one repo was cloned (CI only)

## New server

Adds **svlazdev** (development) mirroring `svldev`, but using the `github_user` format with `archive_mode: true` — clones all non-archived public repos and moves archived ones to `.archive`.

## Validation

- yamllint passes on all changed YAML
- Jinja2 filtering/slicing logic verified with Python
- ansible-lint / syntax-check left to CI (can't run on the Windows dev host)
