### PR TITLE
fix(apt_hold): tolerate not-yet-installed packages on fresh hosts

### DIFF
--- a/ansible/roles/apt_hold/tasks/main.yml
+++ b/ansible/roles/apt_hold/tasks/main.yml
@@ -7,4 +7,8 @@
     selection: hold
   loop: "{{ apt_hold_packages }}"
   when: apt_hold_packages | length > 0
+  register: apt_hold_result
+  failed_when:
+    - apt_hold_result.failed
+    - "'Failed to find package' not in (apt_hold_result.msg | default(''))"
   tags: [apt_hold]

--- a/ansible/roles/apt_hold/tasks/unhold.yml
+++ b/ansible/roles/apt_hold/tasks/unhold.yml
@@ -7,4 +7,8 @@
     selection: install
   loop: "{{ apt_hold_packages }}"
   when: apt_hold_packages | length > 0
+  register: apt_unhold_result
+  failed_when:
+    - apt_unhold_result.failed
+    - "'Failed to find package' not in (apt_unhold_result.msg | default(''))"
   tags: [apt_hold]


### PR DESCRIPTION
## Summary

Fixes a first-time provisioning failure on fresh Docker servers (e.g. the newly added **svlazdev**).

### Problem

The `apt_hold` **unhold** pre-task runs before Docker is installed. On a brand-new host, apt has never seen `docker-ce` and friends, so `dpkg_selections` aborts with:

```
Failed to find package 'docker-ce' to perform selection 'install'.
```

This only surfaces on first-time provisioning — existing servers already have the packages installed, so the unhold succeeds there.

### Fix

Guard both the `hold` and `unhold` `dpkg_selections` tasks with a `failed_when` that tolerates the "Failed to find package" case (there is simply nothing to (un)hold yet). This matches the `failed_when` convention already used in the `git_repos` role. Once Docker is installed later in the play, the `apt_hold` role holds the packages normally.

## Validation

- yamllint passes on the changed files.
- Mirrors an existing, proven `loop` + `register` + `failed_when` pattern in this repo.
