### PR TITLE
fix(svlazdev): unpin Docker versions on Debian Trixie

### DIFF
--- a/ansible/inventory/host_vars/svlazdev.yml
+++ b/ansible/inventory/host_vars/svlazdev.yml
@@ -30,6 +30,21 @@ devcontainer_prebuild_user: jean-paul
 # their referenced images are also protected from image prune
 maintenance_docker_prune_containers_enabled: false
 
+# Docker version handling for Debian Trixie.
+# The docker_servers group pins the bookworm Docker versions (e.g.
+# docker-ce 29.x), but Docker's trixie repository lags behind and does not
+# publish those exact versions yet. Install whatever trixie offers (latest
+# available) and let apt_hold freeze it afterwards so unattended upgrades
+# won't move it. This keeps the dev box self-healing without manual pins.
+docker_packages:
+  - docker-ce
+  - docker-ce-cli
+  - docker-ce-rootless-extras
+  - containerd.io
+  - docker-buildx-plugin
+  - docker-compose-plugin
+docker_compose_package: docker-compose-plugin
+
 # Server features to enable
 server_features:
   - system_setup


### PR DESCRIPTION
## Problem

The fresh `svlazdev` deployment (Debian **Trixie** Azure VM) failed at:

`geerlingguy.docker : Install Docker packages (with downgrade option)` -> `No package matching 'docker-ce' is available`

### Root cause

`inventory/group_vars/docker_servers.yml` pins specific Docker versions (`docker-ce=5:29.4.0*`, `containerd.io=2.3.0*`, `docker-buildx-plugin=0.34.0*`, `docker-compose-plugin=5.1.3*`). These exist in Docker's **bookworm** repo (used by `svldev`), but Docker's **trixie** repo lags behind and tops out around `docker-ce 28.x` / `containerd.io 2.2.4` / `buildx 0.34.1`. apt cannot find the pinned versions, so it reports `docker-ce` as unavailable.

## Fix

Override `docker_packages` and `docker_compose_package` for `svlazdev` only, installing whatever Trixie offers (latest available). The existing `apt_hold` role then freezes the installed versions so unattended upgrades won't move them. This keeps the dev box self-healing without manual per-version pins, and leaves bookworm hosts (`svldev`, `svlazext`) unchanged.

## Testing

- `yamllint` passes on the changed host_vars file.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>