### PR TITLE
fix: Debian Trixie deployment fixes for svlazdev

### DIFF
--- a/ansible/inventory/host_vars/svlazdev.yml
+++ b/ansible/inventory/host_vars/svlazdev.yml
@@ -30,21 +30,6 @@ devcontainer_prebuild_user: jean-paul
 # their referenced images are also protected from image prune
 maintenance_docker_prune_containers_enabled: false
 
-# Docker version handling for Debian Trixie.
-# The docker_servers group pins the bookworm Docker versions (e.g.
-# docker-ce 29.x), but Docker's trixie repository lags behind and does not
-# publish those exact versions yet. Install whatever trixie offers (latest
-# available) and let apt_hold freeze it afterwards so unattended upgrades
-# won't move it. This keeps the dev box self-healing without manual pins.
-docker_packages:
-  - docker-ce
-  - docker-ce-cli
-  - docker-ce-rootless-extras
-  - containerd.io
-  - docker-buildx-plugin
-  - docker-compose-plugin
-docker_compose_package: docker-compose-plugin
-
 # Server features to enable
 server_features:
   - system_setup

--- a/ansible/playbooks/main.yml
+++ b/ansible/playbooks/main.yml
@@ -13,6 +13,28 @@
       when: ansible_os_family == "Debian"
       tags: always
 
+    # geerlingguy.docker only refreshes the apt cache via a handler when it
+    # (re)writes the Docker repository file. If the repo file already exists
+    # from an earlier (possibly interrupted) run, that handler never fires and
+    # the Docker packages can be missing from the cache, causing
+    # "No package matching 'docker-ce' is available". Force an unconditional
+    # refresh whenever the repo file is already present so the Docker packages
+    # are always indexed before the role installs them.
+    - name: Check whether the Docker apt repository is already configured
+      ansible.builtin.stat:
+        path: /etc/apt/sources.list.d/docker.sources
+      register: docker_apt_repo_file
+      when: ansible_os_family == "Debian"
+      tags: always
+
+    - name: Refresh apt cache so an existing Docker repository is indexed
+      ansible.builtin.apt:
+        update_cache: true
+      when:
+        - ansible_os_family == "Debian"
+        - docker_apt_repo_file.stat.exists | default(false)
+      tags: always
+
     - name: Unhold managed apt packages before role execution
       ansible.builtin.include_role:
         name: apt_hold

--- a/ansible/roles/maintenance/tasks/setup_dccd_deploy.yml
+++ b/ansible/roles/maintenance/tasks/setup_dccd_deploy.yml
@@ -1,10 +1,21 @@
 ---
 # Setup for dccd (Docker Compose CD) deployment service
+
+# The legacy cron cleanup below uses ansible.builtin.cron, which requires the
+# crontab executable. Minimal hosts (e.g. fresh Debian Trixie) ship without
+# cron installed. Since this only removes a pre-existing legacy cron job during
+# migration to systemd timers, skip it entirely when crontab is unavailable.
+- name: Check whether crontab is available for legacy cron cleanup
+  ansible.builtin.stat:
+    path: /usr/bin/crontab
+  register: maintenance_crontab_bin
+
 - name: Remove legacy dccd cron job
   ansible.builtin.cron:
     name: "{{ maintenance_dccd_old_cron_name }}"
     user: "{{ maintenance_dccd_user }}"
     state: absent
+  when: maintenance_crontab_bin.stat.exists
 
 - name: Check dccd timer unit files
   ansible.builtin.stat:


### PR DESCRIPTION
Fixes the issues hit while provisioning the new `svlazdev` host (arm64 Debian Trixie Azure VM).

## 1. Refresh apt cache when the Docker repo already exists
`geerlingguy.docker` only runs `apt update` (via a handler) when it (re)writes `/etc/apt/sources.list.d/docker.sources`. If that file already exists from an earlier interrupted run the task is *unchanged*, the handler never fires, and our startup `apt update` is skipped by `cache_valid_time`. The Docker packages then stay absent from the cache, causing `No package matching 'docker-ce' is available` even though the repo publishes them. Added a pre_task that force-refreshes the cache whenever the repo file is already present.

## 2. Skip legacy cron cleanup when crontab is absent
The legacy dccd cron removal uses `ansible.builtin.cron`, which needs the `crontab` binary. Minimal Trixie images ship without cron, so the task failed. Guarded it with a stat check so it only runs when crontab exists (nothing to clean up otherwise).

## 3. Revert the svlazdev Docker version unpin (from #110)
The earlier unpin assumed trixie lacked the pinned versions, but that was based on the **amd64** package list. svlazdev is **arm64**, and the arm64 trixie repo publishes `docker-ce 29.4.0` and newer. The real fix was #1, so svlazdev no longer needs to deviate from the group's pinned versions.

## Testing
- `yamllint` passes on all changed files.