### PR TITLE
fix(svlazdev): unpin Docker versions absent from arm64 Trixie repo

### DIFF
--- a/ansible/inventory/host_vars/svlazdev.yml
+++ b/ansible/inventory/host_vars/svlazdev.yml
@@ -30,6 +30,23 @@ devcontainer_prebuild_user: jean-paul
 # their referenced images are also protected from image prune
 maintenance_docker_prune_containers_enabled: false
 
+# Docker version handling for Debian Trixie (arm64 Azure VM).
+# The docker_servers group pins specific Docker versions that exist in the
+# bookworm repository, but Docker's arm64 trixie repository does not publish
+# all of them (e.g. containerd.io 2.3.0, docker-buildx-plugin 0.34.0 and
+# docker-compose-plugin 5.1.3 are absent there). Install whatever trixie
+# offers (latest available) and let the apt_hold role freeze the installed
+# versions afterwards so unattended upgrades won't move them. This keeps the
+# dev box self-healing without per-release version maintenance.
+docker_packages:
+  - docker-ce
+  - docker-ce-cli
+  - docker-ce-rootless-extras
+  - containerd.io
+  - docker-buildx-plugin
+  - docker-compose-plugin
+docker_compose_package: docker-compose-plugin
+
 # Server features to enable
 server_features:
   - system_setup


### PR DESCRIPTION
## Problem

svlazdev (arm64 Debian Trixie Azure VM) failed at Docker install:

`no available installation candidate for containerd.io=2.3.0*`

## Root cause

The `docker_servers` group pins versions that exist in the **bookworm** repo, but arm64 **Trixie** publishes a different set. Confirmed on the host via `apt-cache policy`:

| Package | Pinned | arm64 Trixie has |
|---|---|---|
| docker-ce | 29.4.0 | 29.4.0 (ok) |
| containerd.io | 2.3.0 | max 2.2.4 |
| docker-buildx-plugin | 0.34.0 | only 0.34.1 |
| docker-compose-plugin | 5.1.3 | only 5.1.4 |

Three of four pins have no candidate on this host.

## Fix

Override `docker_packages` and `docker_compose_package` for svlazdev to install whatever Trixie offers (latest available). The existing `apt_hold` role then freezes the installed versions so unattended upgrades won't move them. Self-healing, no per-release pin maintenance. Bookworm hosts (svldev, svlazext) are unaffected.

Note: this restores the override briefly removed in #111; the host data now confirms it is required (not just docker-ce, but containerd/buildx/compose all lag on arm64 Trixie).

## Testing
- `yamllint` passes on the changed file.