### PR TITLE
refactor(docker): pin apt packages per suite+arch via Renovate deb datasource

### DIFF
--- a/ansible/inventory/group_vars/docker_servers.yml
+++ b/ansible/inventory/group_vars/docker_servers.yml
@@ -4,27 +4,77 @@
 # Silence "discovered Python interpreter" warnings — auto-detect, no warning.
 ansible_python_interpreter: auto_silent
 
-# Docker version pinning
-# renovate: datasource=github-releases depName=moby/moby
-docker_version: "29.4.0"
-# renovate: datasource=github-releases depName=containerd/containerd
-containerd_version: "2.3.0"
-# renovate: datasource=github-releases depName=docker/buildx
-docker_buildx_version: "0.34.0"
-# renovate: datasource=github-releases depName=docker/compose
-docker_compose_version: "5.1.3"
+# --- Docker version pinning (Renovate-managed via the deb datasource) ---
+#
+# Docker publishes different package versions per Debian suite and CPU
+# architecture, and a version released upstream is not necessarily packaged in
+# Docker's apt repository for every suite/arch yet. Versions are therefore
+# pinned per "<suite>-<arch>" combination and kept up to date by Renovate, which
+# queries Docker's apt repository directly (deb datasource) so a pinned version
+# is always installable on the matching host.
+#
+# To add a new suite/arch combination, copy one of the blocks below and change
+# the suite/binaryArch in each Renovate annotation; Renovate then maintains the
+# new versions automatically. Unmapped combinations fall back to unpinned
+# package names (install whatever the repo offers).
+docker_pinned_packages:
+  trixie-amd64:
+    # renovate: datasource=deb depName=docker-ce registryUrl=https://download.docker.com/linux/debian?suite=trixie&components=stable&binaryArch=amd64
+    docker_ce: "5:29.5.2-1~debian.13~trixie"
+    # renovate: datasource=deb depName=containerd.io registryUrl=https://download.docker.com/linux/debian?suite=trixie&components=stable&binaryArch=amd64
+    containerd_io: "2.2.4-1~debian.13~trixie"
+    # renovate: datasource=deb depName=docker-buildx-plugin registryUrl=https://download.docker.com/linux/debian?suite=trixie&components=stable&binaryArch=amd64
+    docker_buildx_plugin: "0.34.1-1~debian.13~trixie"
+    # renovate: datasource=deb depName=docker-compose-plugin registryUrl=https://download.docker.com/linux/debian?suite=trixie&components=stable&binaryArch=amd64
+    docker_compose_plugin: "5.1.4-1~debian.13~trixie"
+  trixie-arm64:
+    # renovate: datasource=deb depName=docker-ce registryUrl=https://download.docker.com/linux/debian?suite=trixie&components=stable&binaryArch=arm64
+    docker_ce: "5:29.5.3-1~debian.13~trixie"
+    # renovate: datasource=deb depName=containerd.io registryUrl=https://download.docker.com/linux/debian?suite=trixie&components=stable&binaryArch=arm64
+    containerd_io: "2.2.4-1~debian.13~trixie"
+    # renovate: datasource=deb depName=docker-buildx-plugin registryUrl=https://download.docker.com/linux/debian?suite=trixie&components=stable&binaryArch=arm64
+    docker_buildx_plugin: "0.34.1-1~debian.13~trixie"
+    # renovate: datasource=deb depName=docker-compose-plugin registryUrl=https://download.docker.com/linux/debian?suite=trixie&components=stable&binaryArch=arm64
+    docker_compose_plugin: "5.1.4-1~debian.13~trixie"
 
-# Override geerlingguy.docker packages with pinned versions
-docker_packages:
-  - "docker-ce=5:{{ docker_version }}*"
-  - "docker-ce-cli=5:{{ docker_version }}*"
-  - "docker-ce-rootless-extras=5:{{ docker_version }}*"
-  - "containerd.io={{ containerd_version }}*"
-  - "docker-buildx-plugin={{ docker_buildx_version }}*"
-  - "docker-compose-plugin={{ docker_compose_version }}*"
+# Map Ansible's reported CPU architecture to Debian's apt architecture name.
+docker_apt_arch_map:
+  x86_64: amd64
+  aarch64: arm64
 
-# Override geerlingguy.docker compose plugin package to match pinned version
-docker_compose_package: "docker-compose-plugin={{ docker_compose_version }}*"
+# Resolve the pinned package set for this host's suite + architecture. Unmapped
+# combinations resolve to an empty mapping and fall back to unpinned names below.
+docker_apt_arch: "{{ docker_apt_arch_map[ansible_architecture] | default(ansible_architecture) }}"
+docker_pin_key: "{{ ansible_distribution_release }}-{{ docker_apt_arch }}"
+docker_pins: "{{ docker_pinned_packages[docker_pin_key] | default({}) }}"
+
+# Override geerlingguy.docker packages with the resolved pinned versions when the
+# host's suite/arch is mapped; otherwise install unpinned (latest available).
+docker_packages: >-
+  {{
+    [
+      'docker-ce=' ~ docker_pins.docker_ce,
+      'docker-ce-cli=' ~ docker_pins.docker_ce,
+      'docker-ce-rootless-extras=' ~ docker_pins.docker_ce,
+      'containerd.io=' ~ docker_pins.containerd_io,
+      'docker-buildx-plugin=' ~ docker_pins.docker_buildx_plugin,
+      'docker-compose-plugin=' ~ docker_pins.docker_compose_plugin,
+    ] if docker_pins else [
+      'docker-ce',
+      'docker-ce-cli',
+      'docker-ce-rootless-extras',
+      'containerd.io',
+      'docker-buildx-plugin',
+      'docker-compose-plugin',
+    ]
+  }}
+
+# Override geerlingguy.docker compose plugin package to match the resolved pin.
+docker_compose_package: >-
+  {{
+    ('docker-compose-plugin=' ~ docker_pins.docker_compose_plugin)
+    if docker_pins else 'docker-compose-plugin'
+  }}
 
 # Packages to hold via apt-mark hold
 # Held packages are skipped by apt-get upgrade and dist-upgrade

--- a/renovate.json5
+++ b/renovate.json5
@@ -57,5 +57,18 @@
       datasourceTemplate: "github-releases",
       packageNameTemplate: "bats-core/bats-core",
     },
+    {
+      customType: "regex",
+      description: "Track Docker apt package versions (deb datasource) in docker_servers group_vars",
+      managerFilePatterns: [
+        "/ansible/inventory/group_vars/docker_servers\\.yml$/",
+      ],
+      matchStrings: [
+        "#\\s*renovate:\\s*datasource=deb\\s+depName=(?<depName>\\S+)\\s+registryUrl=(?<registryUrl>\\S+)\\s*\\r?\\n\\s*\\w+:\\s*\"(?<currentValue>[^\"]+)\"",
+      ],
+      datasourceTemplate: "deb",
+      versioningTemplate: "deb",
+      registryUrlTemplate: "{{{registryUrl}}}",
+    },
   ],
 }


### PR DESCRIPTION
## Problem
Docker version pins in `group_vars/docker_servers.yml` used the `github-releases` datasource, which tracks **upstream** Moby/containerd releases — not what Docker's **apt repo** actually publishes per Debian suite + CPU architecture. All hosts are now Debian **trixie**, and the old bookworm-era pins (e.g. `containerd.io=2.3.0`) don't exist in the trixie apt repo, so installs fail:

```
no available installation candidate for containerd.io=2.3.0*
```

This hit the new arm64 host `svlazdev` and would affect the fleet on the next upgrade.

## Change
- **`group_vars/docker_servers.yml`**: replace single github-releases pins with a `docker_pinned_packages` dict keyed by `<suite>-<arch>`, each version annotated for Renovate's **`deb`** datasource (queries Docker's apt repo directly per `suite`/`components`/`binaryArch`). The pin set is auto-selected at runtime from `ansible_distribution_release` + an arch map (`x86_64→amd64`, `aarch64→arm64`). Unmapped combos fall back to **unpinned** package names (self-healing; also keeps the CI bats runner on ubuntu-noble safe).
- **`renovate.json5`**: add a regex `customManager` that maintains each pinned version against its per-suite/arch `registryUrl`.

### Resolved pins (all trixie)
| suite-arch   | docker-ce | containerd.io | buildx | compose |
|--------------|-----------|---------------|--------|---------|
| trixie-amd64 | 29.5.2    | 2.2.4         | 0.34.1 | 5.1.4   |
| trixie-arm64 | 29.5.3    | 2.2.4         | 0.34.1 | 5.1.4   |

## Validation
- `yamllint` passes on `docker_servers.yml`.
- Jinja resolution simulated for all 3 host combos + an unmapped combo (correct fallback to unpinned).
- Renovate regex simulated: matches all 8 annotations with correct `depName`/`currentValue`/`registryUrl`.
- Unhold-before / hold-after ordering in `main.yml` already lets Renovate version bumps apply cleanly through `apt_hold`.
- ansible-lint can't run on Windows — relying on CI.

Supersedes #112 (svlazdev unpin), which can be closed once this merges.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>